### PR TITLE
Delete the lockfile on stop, even if the process doesn't die.

### DIFF
--- a/templates/default/nodejs.initd.erb
+++ b/templates/default/nodejs.initd.erb
@@ -38,7 +38,8 @@ do_stop()
         kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
         RETVAL=$?
         echo
-        [ $RETVAL -eq 0 ] && rm -f $LOCK_FILE
+        [ $RETVAL -eq 0 ]
+        rm -f $LOCK_FILE
 }
 
 case "$1" in


### PR DESCRIPTION
The node process crashes too much. It makes sense to just wipe the lockfile, regardless of `$?` after `kill -9`. Most times, it's already dead, and the return code is non-zero, but the process is still stopped.
