### PR TITLE
simplified the search stuff, copying it over from how phpstack does mysq...

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ provisioner:
     holland:
       enabled: false
     mysql-multi:
-      bind_ip: '127.0.0.1'
+      master: '127.0.0.1'
     cloud:
       public_ipv4: '127.0.0.1'
     platformstack:
@@ -53,7 +53,7 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[nodestack::mysql_base]
+      - recipe[nodestack::mysql_master]
       - recipe[nodestack::default]
   - name: mysql
     run_list:

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache 2.0'
 description 'Installs/Configures nodestack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version '0.2.2'
+version '0.2.3'
 
 depends 'apt'
 depends 'mysql'

--- a/recipes/application_nodejs.rb
+++ b/recipes/application_nodejs.rb
@@ -3,25 +3,7 @@
 
 include_recipe 'chef-sugar'
 
-# mysql-multi defaults to default['mysql-mutli']['master'] = ''
-if Chef::Config[:solo] # FC003
-  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
-  bindip = '127.0.0.1'
-elsif node.deep_fetch('mysql-multi', 'master') && !node['mysql-multi']['master'].empty?
-  bindip = node['mysql-multi']['master']
-elsif node.deep_fetch('mysql-multi', 'bind_ip') && !node['mysql-multi']['bind_ip'].empty?
-  # if a bind IP is set for the cluster, use it for all app nodes
-  bindip = node['mysql-multi']['bind_ip']
-else
-  if node['mysql-multi']['master'].empty?
-    mysql = search('node', 'recipes:nodestack\:\:mysql_base'\
-               " AND chef_environment:#{node.chef_environment}").first
-  else
-    mysql = search('node', 'recipes:nodestack\:\:mysql_master'\
-               " AND chef_environment:#{node.chef_environment}").first
-  end
-  bindip = best_ip_for(mysql)
-end
+mysql_node = search('node', 'recipes:nodestack\:\:mysql_master' << " AND chef_environment:#{node.chef_environment}").first
 
 node['nodestack']['apps'].each_pair do |app_name, app_config| # each app loop
 
@@ -67,7 +49,7 @@ node['nodestack']['apps'].each_pair do |app_name, app_config| # each app loop
     mode '0644'
     variables(
       http_port: app_config['http_port'],
-      mysql_ip: bindip,
+      mysql: mysql_node.respond_to?('deep_fetch') == true ? mysql_node : nil,
       mysql_user: app_name,
       mysql_password: app_config['mysql_app_user_password'],
       mysql_db_name: app_name

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -4,13 +4,15 @@ config.node = {
   port: <%= @http_port %>
 };
 
+<%- unless @mysql.nil? -%>
 config.mysql = [
   {
-    host: "<%= @mysql_ip %>",
+    host: "<%= node['mysql-multi']['master'] %>",
     usr: "<%= @mysql_user %>",
     pwd: "<%= @mysql_password %>",
     db_name: "<%= @mysql_db_name %>",
   }
+<%- end -%>
 
 ];
 


### PR DESCRIPTION
...l search

what we had was too complicated, and this is how phpstack finds mysql nodes. This still doesn't fix that we need to rerun chef-client for mysql nodes to open up ports for app nodes to be able to reach the database.
