### PR TITLE
Reformat config.js template

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures nodestack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.6.2'
+version '0.6.3'
 
 depends 'apt'
 depends 'mysql'

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -1,13 +1,5 @@
 var config = {};
 
-config = {
-  <% @config_js.each_pair do | directive, config | %>
-    <% if config.is_a?(Integer) %>
-        <%= directive %>: <%= config %>,
-    <% else %>
-        <%= directive %>: "<%= config %>",
-    <% end %>
-  <% end %>
-};
+config = <%= @config_js.to_json %>;
 
 module.exports = config;


### PR DESCRIPTION
Config template breaks on nested configuration like:

``` yaml
app_name:
  config_js:
    mongo:
      uri:
      something_else:
```

The simplest way is to push this out using to_json. This works in testing and customer dev environment.
