### PR TITLE
Use npm-install-retry to work around cb() error

### DIFF
--- a/recipes/application_nodejs.rb
+++ b/recipes/application_nodejs.rb
@@ -157,9 +157,13 @@ node['nodestack']['apps_to_deploy'].each do |app_name| # each app loop
     only_if { app_config['config_file'] }
   end
 
+  execute 'npm install retry' do
+    command 'npm -g install npm-install-retry'
+  end
+
   execute 'Install npm packages from package.json' do
     cwd "#{app_config['app_dir']}/current"
-    command 'npm install'
+    command 'npm-install-retry --wait 60 --attempts 5'
     environment 'HOME' => "/home/#{ app_name }", 'USER' => app_name
     user app_name
     group app_name


### PR DESCRIPTION
npm install failure caused a forever restart loop due to a missing module.

The error message "npm ERR! cb() never called!" is an unresolved open issue with npm: https://github.com/npm/npm/issues/2907

npm-install-retry was created as a work around - https://www.npmjs.org/package/npm-install-retry

This PR contains hard coded values for the npm-install-retry wait and attempts - 60 & 5 respectively.  They probably could be moved to attributes if necessary.

Since an npm installation failure will likely cause application failure, a workaround for the unattended install is necessary; otherwise, the application may be down for an extended period of time.
