### PR TITLE
Allow monitoring URI to be overridden by an attribute. Additionally, use...

### DIFF
--- a/attributes/monitoring.rb
+++ b/attributes/monitoring.rb
@@ -23,6 +23,11 @@ default['nodestack']['cloud_monitoring']['remote_http']['alarm'] = false
 default['nodestack']['cloud_monitoring']['remote_http']['period'] = 60
 default['nodestack']['cloud_monitoring']['remote_http']['timeout'] = 15
 
+# This value is appended to the monitoring URL after the ip:port.
+# For that reason, we default to '/', although '' would work as well.
+# Most overrides would be: uri: '/some/uri'
+default['nodestack']['cloud_monitoring']['remote_http']['uri'] = '/'
+
 default['nodestack']['cloud_monitoring']['agent_mysql']['disabled'] = false
 default['nodestack']['cloud_monitoring']['agent_mysql']['alarm'] = false
 default['nodestack']['cloud_monitoring']['agent_mysql']['period'] = 60

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures nodestack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.3'
+version '0.9.4'
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 supports 'rhel', '>= 6.0'

--- a/templates/default/monitoring-remote-http.yaml.erb
+++ b/templates/default/monitoring-remote-http.yaml.erb
@@ -17,12 +17,12 @@ details:
   hostname: <%= @app_name %>
   method: GET
   body: '<%= @body %>'
-  url: http://<%= "#{node['cloud']['public_ipv4']}:#{@port}" %>
+  url: http://<%= "#{node['cloud']['public_ipv4']}:#{@port}#{node['nodestack']['cloud_monitoring']['remote_http']['uri']}" %>
 <% if node['nodestack']['cloud_monitoring']['remote_http']['alarm'] == true %>
 alarms:
   http-check:
     label: Remote HTTP check on <%= "#{node['cloud']['public_ipv4']} port #{@port} for #{@app_name}" %>
-    notification_plan_id: npTechnicalContactsEmail
+    notification_plan_id: <%= node['platformstack']['cloud_monitoring']['notification_plan_id'] %>
     criteria: |
       if (metric['code'] regex '4[0-9][0-9]') {
         return new AlarmStatus(CRITICAL, 'HTTP server responding with 4xx status');


### PR DESCRIPTION
... the notification_plan_id defined in platformstack
