### PR TITLE
Git dependant repos

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures nodestack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.3.0'
+version '2.4.0'
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 supports 'rhel', '>= 6.0'


### PR DESCRIPTION
Hello,

  Please see https://github.com/AutomationSupport/nodestack/pull/153

  This merges the "git_branch_hack" which allows targeting non-master branches of an application. This issue is found in Ubuntu 14.04 and Chef 11, which is our current "bread and butter".

  This also merges "git_dependant_repos" - this allows us to define an array of git repos which will be checked out into the applications deploy directory after the application has been checked out, but before the service is reset.

  If neither of these change want desired, I'd prefer to stop wasting my time keeping this up to date with master for easy merging (and I'll just skip "application_nodejs" entirely in my customer cookbooks. I'd prefer not to do this).  

  Let me know what else needs to happen. I will clear the older PR.

- Seandon