### PR TITLE
Make setcap optional via attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,4 @@ when 'debian'
 end
 
 default['nodestack']['code_deployment'] = true
+default['nodestack']['bind_low_ports'] = true

--- a/recipes/application_nodejs.rb
+++ b/recipes/application_nodejs.rb
@@ -28,9 +28,13 @@ else
   include_recipe 'apt'
 end
 
-%w(chef-sugar nodejs nodejs::npm git build-essential nodestack::setcap
+%w(chef-sugar nodejs nodejs::npm git build-essential
 ).each do |recipe|
   include_recipe recipe
+end
+
+if node.deep_fetch('nodestack', 'bind_low_ports')
+  include_recipe 'nodestack::setcap'
 end
 
 logging_paths = []


### PR DESCRIPTION
If you are running node on a port higher than port 1024, you might not
want to grant the NET_BIND_SERVICE capability to the node binary. Also
needed for Docker containers which don't support setcap on AUFS.
