### PR TITLE
Disable setcap by default.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,4 +14,4 @@ when 'debian'
 end
 
 default['nodestack']['code_deployment'] = true
-default['nodestack']['bind_low_ports'] = true
+default['nodestack']['bind_low_ports'] = false

--- a/recipes/demo.rb
+++ b/recipes/demo.rb
@@ -18,6 +18,9 @@
 # limitations under the License.
 #
 
+# There's no web server setup as a reverse proxy in the demo, so we still
+# want to use setcap to be able to bind low ports.
+node.set['nodestack']['bind_low_ports'] = true
 node.set['nodestack']['apps']['my_nodejs_app']['app_dir'] = '/var/app'
 node.set['nodestack']['apps']['my_nodejs_app']['app_options'] = []
 node.set['nodestack']['apps']['my_nodejs_app']['git_repo'] = 'git@github.com:marcoamorales/node-hello-world.git'


### PR DESCRIPTION
Saner default. There will most likely be a web server set as reverse
proxy in front of Node.js