### PR TITLE
Unpin forever version

### DIFF
--- a/recipes/forever.rb
+++ b/recipes/forever.rb
@@ -73,7 +73,6 @@ node['nodestack']['apps'].each do |app| # each app loop
 
   nodejs_npm 'forever' do
     path app_config['app_dir']
-    version '0.11.1'
     user app_name
     retries 5
     retry_delay 30


### PR DESCRIPTION
We had to pin the version of forever back in #165 due to a bug that was causing it to behave improperly under centos.

I don't see that this bug was ever documented or reported upstream but it's not present anymore, so I'm unpinning the version.